### PR TITLE
需求反饋

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,8 @@
 
 include $(TOPDIR)/rules.mk
 
-PKG_VERSION:=20221214
-PKG_RELEASE:=1
+PKG_VERSION:=20230126
+PKG_RELEASE:=2
 
 LUCI_TITLE:=LuCI support for Multi Stream Daemon Lite
 LUCI_DEPENDS:=+msd_lite +luci-compat


### PR DESCRIPTION
需要其他架構的安裝文件，謝謝！

aarch64_generic/
arm_cortex-a9_vfpv3-d16/ | - | 2023-Feb-01 00:01
x86_64/ | - | 2023-Jan-31 23:59
i386_pentium4/ | - | 2023-Jan-31 23:58
arm_cortex-a9/ | - | 2023-Jan-31 23:58
mips_24kc/ | - | 2023-Jan-31 23:57
arm_cortex-a5_vfpv4/ | - | 2023-Jan-31 23:57
aarch64_cortex-a53/ | - | 2023-Jan-31 23:56
mipsel_24kc/ | - | 2023-Jan-31 23:55
arm_cortex-a15_neon-vfpv4/ | - | 2023-Jan-31 23:55
arm_xscale/ | - | 2023-Jan-31 23:54
arm_cortex-a7_neon-vfpv4/ 
aarch64_cortex-a72/
